### PR TITLE
Provide properties already in pre-checkout phase

### DIFF
--- a/src/main/java/com/mig82/folders/wrappers/ParentFolderBuildWrapper.java
+++ b/src/main/java/com/mig82/folders/wrappers/ParentFolderBuildWrapper.java
@@ -31,6 +31,12 @@ public class ParentFolderBuildWrapper extends SimpleBuildWrapper{
 	@DataBoundConstructor
 	public ParentFolderBuildWrapper(){}
 
+
+	@Override
+	protected boolean runPreCheckout() {
+        return true;
+    }
+	
 	//Add the properties from the parent ProjectFolder folder to the context of the job before it starts.
 	@Override
 	public void setUp(


### PR DESCRIPTION
provide folder properties earlier

provide properties already in the pre checkout phase, so that a property can be used e.g. as branch name.