### PR TITLE
Fix JSR-305 annotations

### DIFF
--- a/src/main/java/com/mig82/folders/properties/FolderProperties.java
+++ b/src/main/java/com/mig82/folders/properties/FolderProperties.java
@@ -4,6 +4,7 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.mig82.folders.Messages;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.CopyOnWriteList;
@@ -13,7 +14,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -95,7 +95,7 @@ public class FolderProperties<C extends AbstractFolder<?>> extends AbstractFolde
 	@Extension
 	public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 


### PR DESCRIPTION
## Fix JSR-305 annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant [Java specification request JSR-305](https://jcp.org/en/jsr/detail?id=305). The proposal never became a part of standard Java. Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

Refer to the [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord for more details.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) performs the transformation.

The [improve a plugin tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) recommends the transformation and describes the rationale.

### Testing done

Confirmed that `mvn clean verify` passes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
