### PR TITLE
Use correct documentation URL in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,7 @@
       </developer>
     </developers>
 
-    <!-- Assuming you want to host on @jenkinsci:-->
-    <url>https://wiki.jenkins.io/display/JENKINS/Folder+Properties+Plugin</url>
+    <url>https://github.com/jenkinsci/folder-properties-plugin/</url>
     <scm>
         <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
## Use correct documentation URL in pom file

Documentation move from wiki to GitHub is not complete until the url in the pom file points to the GitHub repository and a new release of the plugin has been delivered.

### Testing done

Confirmed that the URL is correct for the repository

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
