### PR TITLE
Remove unused developers section from pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,29 +9,19 @@
     </parent>
     <groupId>com.mig82</groupId>
     <artifactId>folder-properties</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.baseline>2.452</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     </properties>
     <name>Folder Properties Plugin</name>
-    <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>
             <name>MIT License</name>
             <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
-
-    <!-- If you want this to appear on the wiki page:-->
-    <developers>
-      <developer>
-        <id>mig82</id>
-        <name>Miguelangel Fernandez</name>
-        <email>miguelangelxfm@gmail.com</email>
-      </developer>
-    </developers>
 
     <url>https://github.com/jenkinsci/folder-properties-plugin/</url>
     <scm>


### PR DESCRIPTION
## Remove unused developers section from pom file

Jenkins repository permissions updater records the maintainers of each plugin and assures that permissions are correctly granted to those maintainers.

Refer to the [specific file](https://github.com/jenkins-infra/repository-permissions-updater/blob/master/permissions/plugin-folder-properties.yml) for this plugin.

The [plugins site](https://plugins.jenkins.io/folder-properties/) shows current maintainers:

* Miguelángel Fernández (@mig82)
* Mark Waite (@MarkEWaite)

### Testing done

Confirmed that `mvn clean verify` passes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
