### PR TITLE
Enable continuous delivery on significant merges to master branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
   directory: /
   schedule:
     interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,54 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+#
+# Please find additional hints for individual trigger use case
+# configuration options inline this script below.
+#
+---
+name: cd
+on:
+  workflow_dispatch:
+    inputs:
+      validate_only:
+        required: false
+        type: boolean
+        description: |
+          Run validation with release drafter only
+          → Skip the release job
+        # Note: Change this default to true,
+        #       if the checkbox should be checked by default.
+        default: false
+  # If you don't want any automatic trigger in general, then
+  # the following check_run trigger lines should all be commented.
+  # Note: Consider the use case #2 config for 'validate_only' below
+  #       as an alternative option!
+  check_run:
+    types:
+      - completed
+
+permissions:
+  checks: read
+  contents: write
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    with:
+      # Comment / uncomment the validate_only config appropriate to your preference:
+      #
+      # Use case #1 (automatic release):
+      #   - Let any successful Jenkins build trigger another release,
+      #     if there are merged pull requests of interest
+      #   - Perform a validation only run with drafting a release note,
+      #     if manually triggered AND inputs.validate_only has been checked.
+      #
+      validate_only: ${{ inputs.validate_only == true }}
+      #
+      # Alternative use case #2 (no automatic release):
+      #   - Same as use case #1 - but:
+      #     - Let any check_run trigger a validate_only run.
+      #       => enforce the release job to be skipped.
+      #
+      #validate_only: ${{ inputs.validate_only == true || github.event_name == 'check_run' }}
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.mig82</groupId>
   <artifactId>folder-properties</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>${changelist}</version>
   <packaging>hpi</packaging>
   <name>Folder Properties Plugin</name>
 
@@ -29,8 +29,7 @@
   </scm>
 
   <properties>
-    <revision>1.3.0</revision>
-    <changelist>-SNAPSHOT</changelist>
+    <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/folder-properties-plugin</gitHubRepo>
     <jenkins.baseline>2.452</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.4</jenkins.version>


### PR DESCRIPTION
## Enable continuous delivery on significant merges to master branch

The [developer documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) describes the transition and explains the benefits of continuous delivery as:

> Maintainers of Jenkins plugin repositories on GitHub can opt into continuous delivery (CD). In this mode, every successful build of the default branch (master or main) by ci.jenkins.io results in a new plugin release. GitHub Actions are used to rebuild the code and deploy it to Artifactory, without the need for maintainers to use personal credentials or local builds. Release notes are generated automatically according to pull request (PR) titles and some predefined labels.

[JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc) provides the technical details of continuous delivery of Jenkins components and plugins

### Testing done

Reviewed the documentation steps in detail to confirm they are correct.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
