### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
   <groupId>com.mig82</groupId>
@@ -31,8 +31,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/folder-properties-plugin</gitHubRepo>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/mig82/folders/properties/FolderProperties.java
+++ b/src/main/java/com/mig82/folders/properties/FolderProperties.java
@@ -14,7 +14,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * A class that holds an array of properties for a folder.
@@ -39,7 +39,7 @@ public class FolderProperties<C extends AbstractFolder<?>> extends AbstractFolde
     }
 
     @Override
-    public AbstractFolderProperty<?> reconfigure(StaplerRequest request, JSONObject formData)
+    public AbstractFolderProperty<?> reconfigure(StaplerRequest2 request, JSONObject formData)
             throws Descriptor.FormException {
         if (formData == null) {
             return null;

--- a/src/main/java/com/mig82/folders/properties/PropertiesLoader.java
+++ b/src/main/java/com/mig82/folders/properties/PropertiesLoader.java
@@ -24,9 +24,8 @@ public class PropertiesLoader {
         EnvVars envVars = new EnvVars();
         // Look in all the ancestors...
         while (parent != null) {
-            if (parent instanceof AbstractFolder) {
+            if (parent instanceof AbstractFolder folder) {
                 LOGGER.log(Level.FINEST, "2. Searching for folder properties in: {0}\n", parent.getDisplayName());
-                AbstractFolder folder = (AbstractFolder) parent;
                 FolderProperties folderProperties =
                         (FolderProperties) folder.getProperties().get(FolderProperties.class);
                 if (folderProperties != null) {
@@ -59,8 +58,8 @@ public class PropertiesLoader {
                 });
             }
             // In the next iteration we want to search for the parent of this parent.
-            if (parent instanceof Item) {
-                parent = ((Item) parent).getParent();
+            if (parent instanceof Item item) {
+                parent = item.getParent();
             } else {
                 parent = null;
             }

--- a/src/main/java/com/mig82/folders/step/FolderPropertiesStep.java
+++ b/src/main/java/com/mig82/folders/step/FolderPropertiesStep.java
@@ -7,6 +7,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
@@ -57,7 +58,9 @@ public class FolderPropertiesStep extends Step implements Serializable {
     }
 
     private static final class ExpanderImpl extends EnvironmentExpander {
+        @Serial
         private static final long serialVersionUID = 1;
+
         private final EnvVars overrides;
 
         ExpanderImpl(EnvVars overrides) {

--- a/src/test/java/com/mig82/folders/FolderPropertiesTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesTest.java
@@ -10,12 +10,17 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class FolderPropertiesTest {
     @ClassRule
     public static JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public TestName name = new TestName();
 
     private static Folder f;
 
@@ -78,11 +83,14 @@ public class FolderPropertiesTest {
         // Create a pipeline job which uses the properties from its parent folder.
         WorkflowJob p = PipelineTestHelper.createJob(
                 f,
-                "p-3",
-                "node {\n" + "  wrap([$class: 'ParentFolderBuildWrapper']) {\n"
-                        + "    echo(\"key1: ${env.key1}\")\n"
-                        + "  }\n"
-                        + "}");
+                "p-" + name.getMethodName(),
+                """
+                node {
+                  wrap([$class: 'ParentFolderBuildWrapper']) {
+                    echo("key1: ${env.key1}")
+                  }
+                }
+                """);
 
         // Run the build
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -97,8 +105,14 @@ public class FolderPropertiesTest {
         // Create a pipeline job which uses the properties from its parent folder.
         WorkflowJob p = PipelineTestHelper.createJob(
                 f,
-                "p-4",
-                "node {\n" + "  withFolderProperties {\n" + "    echo(\"key1: ${env.key1}\")\n" + "  }\n" + "}");
+                "p-" + name.getMethodName(),
+                """
+                node {
+                  withFolderProperties {
+                    echo("key1: ${env.key1}")
+                  }
+                }
+                """);
 
         // Run the build
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -113,18 +127,21 @@ public class FolderPropertiesTest {
         // Create a declarative pipeline job which uses the properties from its parent folder.
         WorkflowJob p = PipelineTestHelper.createJob(
                 f,
-                "p-5",
-                "pipeline {\n" + "  agent any\n"
-                        + "  stages {\n"
-                        + "    stage('Report folder property key1') {\n"
-                        + "      steps {\n"
-                        + "        withFolderProperties {\n"
-                        + "          echo \"key1: ${env.key1}\"\n"
-                        + "        }\n"
-                        + "      }\n"
-                        + "    }\n"
-                        + "  }\n"
-                        + "}\n");
+                "p-" + name.getMethodName(),
+                """
+                pipeline {
+                  agent any
+                  stages {
+                    stage('Report folder property key1') {
+                      steps {
+                        withFolderProperties {
+                          echo "key1: ${env.key1}"
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
 
         // Run the build
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -138,7 +155,13 @@ public class FolderPropertiesTest {
 
         // Create a pipeline job which uses the properties from its parent folder.
         WorkflowJob p = PipelineTestHelper.createJob(
-                f, "p-6", "withFolderProperties {\n" + "  echo(\"key1: ${env.key1}\")\n" + "}");
+                f,
+                "p-" + name.getMethodName(),
+                """
+                withFolderProperties {
+                  echo("key1: ${env.key1}")
+                }
+                """);
 
         // Run the build
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -161,12 +184,15 @@ public class FolderPropertiesTest {
         // Create a pipeline job inside the subfolder which uses the properties from its parent folder.
         WorkflowJob p = PipelineTestHelper.createJob(
                 sub,
-                "p-7",
-                "node {\n" + "  wrap([$class: 'ParentFolderBuildWrapper']){\n"
-                        + "    echo(\"key1: ${env.key1}\")\n"
-                        + "    echo(\"key2: ${env.key2}\")\n"
-                        + "  }\n"
-                        + "}");
+                "p-" + name.getMethodName(),
+                """
+                node {
+                  wrap([$class: 'ParentFolderBuildWrapper']){
+                    echo("key1: ${env.key1}")
+                    echo("key2: ${env.key2}")
+                  }
+                }
+                """);
 
         // Run the build
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -182,13 +208,16 @@ public class FolderPropertiesTest {
         // Create a pipeline job which uses the properties from its parent folder.
         WorkflowJob p = PipelineTestHelper.createJob(
                 f,
-                "p-8",
-                "withEnv(['key1=old']) {\n" + "  node {\n"
-                        + "    wrap([$class: 'ParentFolderBuildWrapper']){\n"
-                        + "      echo(\"key1: ${env.key1}\")\n"
-                        + "    }\n"
-                        + "  }\n"
-                        + "}");
+                "p-" + name.getMethodName(),
+                """
+                withEnv(['key1=old']) {
+                  node {
+                    wrap([$class: 'ParentFolderBuildWrapper']){
+                      echo("key1: ${env.key1}")
+                    }
+                  }
+                }
+                """);
 
         // Run the build
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Require Jenkins minimum LTS version for Spring Security 6, Eclipse Jetty 12, Jakarta EE 9, and Java 17.  Reduce use of compatibility layer by plugins.

Also includes updates to use Java 17 features to improve code readability.

- Use Java 17 pattern matching instanceof for simpler code
- Use Java 17 text blocks for more readable tests
- Use Java 17 Serial annotation in hopes it helps future analysis

Replaces pull request:

* #21

### Testing done

Confirmed that `mvn clean verify` works as expected.

Confirmed that there are no plugins that depend on this plugin, so the change in the public API is safe.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
