### PR TITLE
Remove unnecessary runtime dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,33 +56,19 @@
       <artifactId>cloudbees-folder</artifactId>
     </dependency>
 
-    <!--Need this of pipeline custom step -->
+    <!--Need this for Pipeline custom step -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-api</artifactId>
-    </dependency>
 
-    <!--Need these for declarative pipeline test -->
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-definition</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-extensions</artifactId>
-    </dependency>
-
+    <!--Need these to test scripted Pipeline jobs -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
       <scope>test</scope>
     </dependency>
 
-    <!--Need these in order to be able to test on pipeline jobs-->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
@@ -92,6 +78,25 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--Need these to test declarative Pipeline jobs -->
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-extensions</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Remove unnecessary runtime dependencies

Earlier changes incorrectly added the declarative Pipeline plugins as runtime dependencies when they are not necessary at runtime.  They are only needed for tests.

### Testing done

Confirmed that `mvn clean verify` succeeds.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
