### PR TITLE
Restore the options documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and over again for all the jobs inside a folder.
 To configure, just create a
 [folder](https://plugins.jenkins.io/cloudbees-folder/),
 go to its configuration page and add as many properties as you need
-under the `Folder Properties` section.
+under the `Folder Properties` section.
 
 In structures where two or more folders are nested, any property defined for a folder will be overridden by any other
 property of the same name defined by one of its sub-folders.
@@ -55,6 +55,24 @@ Pipeline jobs can use step `withFolderProperties` to access them :
 ``` groovy
 withFolderProperties{
     echo("Foo: ${env.FOO}")
+}
+```
+
+Declarative pipeline jobs can also use the `options` directive to leverage folder properties as follows:
+
+``` groovy
+pipeline {
+    agent any
+    options {
+        withFolderProperties()
+    }
+    stages {
+        stage('Test') {
+            steps {
+                echo("Foo: ${env.FOO}")
+            }
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
## Restore the options documentation

Confirmed that it works as documented.  The declarative directive generator does not provide correct syntax, because it suggests:

```
options {
    withFolderProperties
}
```

The documentation syntax works:

```
options {
    withFolderProperties()
}
```

### Testing done

Tested with plugin versions 1.2.1 and 62.v1636b_4a_84608.  Both behaved as described above.  No regression in the transition to the new Jenkins baseline.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
