### PR TITLE
Fix folder properties in Declarative, SCM, and resumable Pipelines

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -18,4 +18,4 @@ jobs:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      # java-version: 21 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.
+      java-version: 21

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,11 @@ Your pull request will be evaluated by the [Jenkins job](https://ci.jenkins.io/j
 
 Before submitting your change, please assure that you've added tests that verify the change.
 
+## Development requirements
+
+Use a full JDK 21 and Maven 3.9.6 or newer. The plugin targets Jenkins 2.568.1
+LTS and newer releases and does not support building or running on Java 17.
+
 ## Code formatting
 
 Source code and pom file formatting is maintained by the `spotless` maven plugin.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before submitting your change, please assure that you've added tests that verify
 
 ## Development requirements
 
-Use a full JDK 21 and Maven 3.9.6 or newer. The plugin targets Jenkins 2.568.1
+Use a full JDK 21 and Maven 3.9.6 or newer. The plugin targets Jenkins 2.555.3
 LTS and newer releases and does not support building or running on Java 17.
 
 ## Code formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,12 @@ Please don't introduce new spotbugs output.
 
 ## Code coverage
 
-Code coverage reporting is available as a maven target.
-Please try to improve code coverage with tests when you submit pull requests.
+Code coverage reporting is available as a Maven profile. The build enforces a
+minimum of 90% line coverage and 80% branch coverage whenever JaCoCo execution
+data is available. Please improve or preserve coverage with tests when you
+submit pull requests.
 
-* `mvn -P enable-jacoco clean install jacoco:report` reports code coverage
+* `mvn -Penable-jacoco clean verify` reports and checks code coverage
 
 ### Reviewing code coverage
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useContainerAgent: false, // Let the pipeline library configure the requested JDK on VM agents
   configurations: [
-    [platform: 'linux', jdk: 21],
+    [platform: 'linux', jdk: 25],
     [platform: 'windows', jdk: 21],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'windows', jdk: 21],
 ])

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ under the `Folder Properties` section.
 In structures where two or more folders are nested, any property defined for a folder will be overridden by any other
 property of the same name defined by one of its sub-folders.
 
+Property names follow Jenkins environment semantics and are case-insensitive
+for precedence. For example, `FOO` and `foo` are treated as the same key, and
+the definition in the closest folder wins.
+
 ![](docs/images/folder-properties-config.png)
 
 By default, folder properties keep their original opt-in behavior: Freestyle
@@ -31,10 +35,16 @@ closer folder defines the same key, the closer definition controls both its
 value and whether it is exposed at build start.
 
 Build-start values are defaults: build parameters and explicit Pipeline
-environment declarations can override them. Jenkins snapshots the resolved
-folder properties the first time a build requests its environment, so the same
-values are used for SCM configuration, Pipeline execution, and controller
-restart recovery even if folder configuration changes while the build runs.
+environment declarations can override them. When at least one resolved key is
+exposed at build start, Jenkins snapshots the resolved folder properties the
+first time the build requests its environment. The same values are then used
+for SCM configuration, Pipeline execution, and controller restart recovery
+even if folder configuration changes while the build runs.
+
+When build-start exposure is not enabled, no persistent snapshot is added to
+the build. Freestyle wrappers and `withFolderProperties` resolve the current
+folder configuration when they run, preserving the behavior of earlier plugin
+versions.
 
 ## Freestyle Jobs
 
@@ -154,6 +164,26 @@ folder('my folder') {
 Folder properties are ordinary environment variables, not credentials. Do not
 store secrets in them; use Jenkins credentials and a credentials-binding step
 for sensitive values.
+
+## Upgrade compatibility
+
+Existing folder configurations do not require migration. The new
+`exposeAtBuildStart` setting defaults to `false`, so existing jobs retain their
+scoped and dynamically resolved behavior.
+
+The corrected `withFolderProperties` step now returns its body's result instead
+of always returning `null`. Pipelines that explicitly depended on the old
+incorrect `null` result should be updated.
+
+Before upgrading from a version with the synchronous implementation, allow
+builds currently executing inside `withFolderProperties` to finish. Those old
+in-flight executions were not restartable. Builds started after the upgrade use
+the resumable implementation.
+
+Builds using build-start exposure persist a
+`FolderPropertiesSnapshotAction`. Back up Jenkins before deployment and avoid
+downgrading without validating old-data handling while such build records are
+retained, since older plugin versions do not contain that action class.
 
 ## Authors & Contributors
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ property of the same name defined by one of its sub-folders.
 
 ![](docs/images/folder-properties-config.png)
 
+By default, folder properties keep their original opt-in behavior: Freestyle
+jobs need the build wrapper and Pipeline jobs need `withFolderProperties` or
+the corresponding Declarative option.
+
+Enable **Expose these properties at build start** on a folder when its values
+must be available before a wrapper or Pipeline step can run. This is required
+for top-level Declarative `environment` expressions and Pipeline-from-SCM job
+definitions. The setting applies to properties defined on that folder. If a
+closer folder defines the same key, the closer definition controls both its
+value and whether it is exposed at build start.
+
+Build-start values are defaults: build parameters and explicit Pipeline
+environment declarations can override them. Jenkins snapshots the resolved
+folder properties the first time a build requests its environment, so the same
+values are used for SCM configuration, Pipeline execution, and controller
+restart recovery even if folder configuration changes while the build runs.
+
 ## Freestyle Jobs
 
 Freestyle jobs must opt into the `Folder Properties` build wrapper from
@@ -76,6 +93,42 @@ pipeline {
 }
 ```
 
+When build-start exposure is enabled on the folder, a top-level Declarative
+`environment` block can derive values from folder properties:
+
+```groovy
+pipeline {
+    agent any
+    options {
+        withFolderProperties()
+    }
+    environment {
+        ARTIFACT_PATH = "${env.PROJECT_NAME}/artifacts"
+    }
+    stages {
+        stage('Test') {
+            steps {
+                echo("Artifact path: ${env.ARTIFACT_PATH}")
+            }
+        }
+    }
+}
+```
+
+The block step propagates its body's result and can remain active across a
+Jenkins controller restart.
+
+### Pipeline from SCM
+
+Build-start properties are also available while Jenkins creates a
+Pipeline-from-SCM definition. They can be used in the Git repository URL,
+branch, and Jenkinsfile script path when lightweight checkout is disabled.
+
+Git lightweight checkout currently expands the branch and script path, but the
+Git plugin does not expand environment variables in the remote URL on that
+path. Use a fixed remote URL or disable lightweight checkout when the URL
+contains a folder property reference.
+
 ## Job DSL
 
 In Job DSL scripts you can define folder properties like so :
@@ -86,6 +139,7 @@ In Job DSL scripts you can define folder properties like so :
 folder('my folder') {
     properties {
         folderProperties {
+            exposeAtBuildStart(true)
             properties {
                 stringProperty {
                     key('FOO')
@@ -96,6 +150,10 @@ folder('my folder') {
     }
 }
 ```
+
+Folder properties are ordinary environment variables, not credentials. Do not
+store secrets in them; use Jenkins credentials and a credentials-binding step
+for sensitive values.
 
 ## Authors & Contributors
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and over again for all the jobs inside a folder.
 
 ## Requirements
 
-The plugin supports Jenkins 2.568.1 LTS and newer releases. Supported Jenkins
+The plugin supports Jenkins 2.555.3 LTS and newer releases. Supported Jenkins
 controllers must run on Java 21 or a newer Java version supported by Jenkins.
 Older Jenkins and Java 17 installations are not supported.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ within it or in any of its sub-folders.
 The aim here is to remove the need to specify the same properties over
 and over again for all the jobs inside a folder.
 
+## Requirements
+
+The plugin supports Jenkins 2.568.1 LTS and newer releases. Supported Jenkins
+controllers must run on Java 21 or a newer Java version supported by Jenkins.
+Older Jenkins and Java 17 installations are not supported.
+
 ## How to use?
 
 To configure, just create a

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2189.v695a_c41f5249</version>
+    <version>6.2211.v27f680c93c53</version>
     <relativePath />
   </parent>
   <groupId>com.mig82</groupId>
@@ -31,8 +31,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/folder-properties-plugin</gitHubRepo>
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.568</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>6715.v52b_c00222d1e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/folder-properties-plugin</gitHubRepo>
-    <jenkins.baseline>2.568</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@
       <artifactId>workflow-step-api</artifactId>
     </dependency>
 
+    <!-- Exercise Pipeline-from-SCM expansion. -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!--Need these to test scripted Pipeline jobs -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -115,5 +122,42 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>coverage-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.90</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.80</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/src/main/java/com/mig82/folders/environment/FolderPropertiesEnvironmentContributor.java
+++ b/src/main/java/com/mig82/folders/environment/FolderPropertiesEnvironmentContributor.java
@@ -17,6 +17,6 @@ public final class FolderPropertiesEnvironmentContributor extends EnvironmentCon
     @SuppressWarnings("rawtypes")
     public void buildEnvironmentFor(Run run, EnvVars env, TaskListener listener)
             throws IOException, InterruptedException {
-        FolderPropertiesSnapshotAction.getOrCreate(run);
+        FolderPropertiesSnapshotAction.createForBuildStart(run);
     }
 }

--- a/src/main/java/com/mig82/folders/environment/FolderPropertiesEnvironmentContributor.java
+++ b/src/main/java/com/mig82/folders/environment/FolderPropertiesEnvironmentContributor.java
@@ -1,0 +1,22 @@
+package com.mig82.folders.environment;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+
+/**
+ * Contributes opted-in folder properties before Pipeline and SCM configuration is evaluated.
+ */
+@Extension
+public final class FolderPropertiesEnvironmentContributor extends EnvironmentContributor {
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void buildEnvironmentFor(Run run, EnvVars env, TaskListener listener)
+            throws IOException, InterruptedException {
+        FolderPropertiesSnapshotAction.getOrCreate(run);
+    }
+}

--- a/src/main/java/com/mig82/folders/environment/FolderPropertiesSnapshotAction.java
+++ b/src/main/java/com/mig82/folders/environment/FolderPropertiesSnapshotAction.java
@@ -11,7 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Stores the immutable folder property snapshot used throughout one build.
+ * Stores the immutable folder property snapshot used by a build that opts into build-start exposure.
  */
 public final class FolderPropertiesSnapshotAction extends InvisibleAction implements EnvironmentContributingAction {
 
@@ -48,19 +48,34 @@ public final class FolderPropertiesSnapshotAction extends InvisibleAction implem
         env.overrideExpandingAll(defaults);
     }
 
-    public static FolderPropertiesSnapshotAction getOrCreate(Run<?, ?> run) {
+    /**
+     * Creates a persistent snapshot only when at least one resolved property is exposed at build start.
+     */
+    public static void createForBuildStart(Run<?, ?> run) {
         FolderPropertiesSnapshotAction existing = run.getAction(FolderPropertiesSnapshotAction.class);
         if (existing != null) {
-            return existing;
+            return;
         }
 
         synchronized (run) {
             existing = run.getAction(FolderPropertiesSnapshotAction.class);
             if (existing == null) {
-                existing = new FolderPropertiesSnapshotAction(new FolderPropertyResolver().resolve(run.getParent()));
-                run.addAction(existing);
+                ResolvedFolderProperties resolved = new FolderPropertyResolver().resolve(run.getParent());
+                if (!resolved.getBuildStartValues().isEmpty()) {
+                    run.addAction(new FolderPropertiesSnapshotAction(resolved));
+                }
             }
-            return existing;
         }
+    }
+
+    /**
+     * Returns the persistent build-start snapshot when present, otherwise resolves the current folder configuration.
+     */
+    public static Map<String, String> resolveValues(Run<?, ?> run) {
+        FolderPropertiesSnapshotAction existing = run.getAction(FolderPropertiesSnapshotAction.class);
+        if (existing != null) {
+            return existing.getValues();
+        }
+        return new FolderPropertyResolver().resolve(run.getParent()).getValues();
     }
 }

--- a/src/main/java/com/mig82/folders/environment/FolderPropertiesSnapshotAction.java
+++ b/src/main/java/com/mig82/folders/environment/FolderPropertiesSnapshotAction.java
@@ -1,0 +1,66 @@
+package com.mig82.folders.environment;
+
+import com.mig82.folders.properties.FolderPropertyResolver;
+import com.mig82.folders.properties.ResolvedFolderProperties;
+import hudson.EnvVars;
+import hudson.model.EnvironmentContributingAction;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Stores the immutable folder property snapshot used throughout one build.
+ */
+public final class FolderPropertiesSnapshotAction extends InvisibleAction implements EnvironmentContributingAction {
+
+    private final Map<String, String> values;
+    private final Map<String, String> buildStartValues;
+    private final Map<String, String> sources;
+
+    private FolderPropertiesSnapshotAction(ResolvedFolderProperties resolved) {
+        values = new LinkedHashMap<>(resolved.getValues());
+        buildStartValues = new LinkedHashMap<>(resolved.getBuildStartValues());
+        sources = new LinkedHashMap<>(resolved.getSources());
+    }
+
+    public Map<String, String> getValues() {
+        return Collections.unmodifiableMap(values);
+    }
+
+    public Map<String, String> getBuildStartValues() {
+        return Collections.unmodifiableMap(buildStartValues);
+    }
+
+    public Map<String, String> getSources() {
+        return Collections.unmodifiableMap(sources);
+    }
+
+    @Override
+    public void buildEnvironment(Run<?, ?> run, EnvVars env) {
+        EnvVars defaults = new EnvVars();
+        for (Map.Entry<String, String> entry : buildStartValues.entrySet()) {
+            if (!env.containsKey(entry.getKey())) {
+                defaults.put(entry.getKey(), entry.getValue());
+            }
+        }
+        env.overrideExpandingAll(defaults);
+    }
+
+    public static FolderPropertiesSnapshotAction getOrCreate(Run<?, ?> run) {
+        FolderPropertiesSnapshotAction existing = run.getAction(FolderPropertiesSnapshotAction.class);
+        if (existing != null) {
+            return existing;
+        }
+
+        synchronized (run) {
+            existing = run.getAction(FolderPropertiesSnapshotAction.class);
+            if (existing == null) {
+                existing = new FolderPropertiesSnapshotAction(new FolderPropertyResolver().resolve(run.getParent()));
+                run.addAction(existing);
+            }
+            return existing;
+        }
+    }
+}

--- a/src/main/java/com/mig82/folders/properties/FolderProperties.java
+++ b/src/main/java/com/mig82/folders/properties/FolderProperties.java
@@ -11,7 +11,6 @@ import hudson.util.CopyOnWriteList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -30,6 +29,8 @@ public class FolderProperties<C extends AbstractFolder<?>> extends AbstractFolde
      */
     private final CopyOnWriteList<StringProperty> properties = new CopyOnWriteList<StringProperty>();
 
+    private boolean exposeAtBuildStart;
+
     /**
      * Constructor.
      */
@@ -45,6 +46,7 @@ public class FolderProperties<C extends AbstractFolder<?>> extends AbstractFolde
             return null;
         }
 
+        exposeAtBuildStart = formData.optBoolean("exposeAtBuildStart");
         properties.replaceBy(request.bindJSONToList(StringProperty.class, formData.get("properties")));
         return this;
     }
@@ -66,10 +68,19 @@ public class FolderProperties<C extends AbstractFolder<?>> extends AbstractFolde
      */
     @DataBoundSetter
     public void setProperties(StringProperty[] properties) {
-        LOGGER.log(Level.FINER, "FolderProperties.setProperties({0})\n", ArrayUtils.toString(properties));
+        LOGGER.log(Level.FINER, "Adding {0} folder properties", properties.length);
         for (StringProperty property : properties) {
             this.properties.add(property);
         }
+    }
+
+    public boolean isExposeAtBuildStart() {
+        return exposeAtBuildStart;
+    }
+
+    @DataBoundSetter
+    public void setExposeAtBuildStart(boolean exposeAtBuildStart) {
+        this.exposeAtBuildStart = exposeAtBuildStart;
     }
 
     /*

--- a/src/main/java/com/mig82/folders/properties/FolderPropertyResolver.java
+++ b/src/main/java/com/mig82/folders/properties/FolderPropertyResolver.java
@@ -4,8 +4,8 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -17,9 +17,9 @@ public final class FolderPropertyResolver {
     private static final Logger LOGGER = Logger.getLogger(FolderPropertyResolver.class.getName());
 
     public ResolvedFolderProperties resolve(Job<?, ?> job) {
-        Map<String, String> values = new LinkedHashMap<>();
-        Map<String, String> buildStartValues = new LinkedHashMap<>();
-        Map<String, String> sources = new LinkedHashMap<>();
+        Map<String, String> values = environmentMap();
+        Map<String, String> buildStartValues = environmentMap();
+        Map<String, String> sources = environmentMap();
         ItemGroup<?> parent = job.getParent();
 
         while (parent != null) {
@@ -41,6 +41,10 @@ public final class FolderPropertyResolver {
                 Level.FINER, "Resolved {0} folder property keys for {1}", new Object[] {values.size(), job.getFullName()
                 });
         return new ResolvedFolderProperties(values, buildStartValues, sources);
+    }
+
+    private static Map<String, String> environmentMap() {
+        return new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     }
 
     private static void addProperties(

--- a/src/main/java/com/mig82/folders/properties/FolderPropertyResolver.java
+++ b/src/main/java/com/mig82/folders/properties/FolderPropertyResolver.java
@@ -1,0 +1,65 @@
+package com.mig82.folders.properties;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Resolves folder properties without coupling lookup to a particular build integration.
+ */
+public final class FolderPropertyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(FolderPropertyResolver.class.getName());
+
+    public ResolvedFolderProperties resolve(Job<?, ?> job) {
+        Map<String, String> values = new LinkedHashMap<>();
+        Map<String, String> buildStartValues = new LinkedHashMap<>();
+        Map<String, String> sources = new LinkedHashMap<>();
+        ItemGroup<?> parent = job.getParent();
+
+        while (parent != null) {
+            if (parent instanceof AbstractFolder<?> folder) {
+                FolderProperties<?> folderProperties = folder.getProperties().get(FolderProperties.class);
+                if (folderProperties != null) {
+                    addProperties(folder, folderProperties, values, buildStartValues, sources);
+                }
+            }
+
+            if (parent instanceof Item item) {
+                parent = item.getParent();
+            } else {
+                break;
+            }
+        }
+
+        LOGGER.log(
+                Level.FINER, "Resolved {0} folder property keys for {1}", new Object[] {values.size(), job.getFullName()
+                });
+        return new ResolvedFolderProperties(values, buildStartValues, sources);
+    }
+
+    private static void addProperties(
+            AbstractFolder<?> folder,
+            FolderProperties<?> folderProperties,
+            Map<String, String> values,
+            Map<String, String> buildStartValues,
+            Map<String, String> sources) {
+        for (StringProperty property : folderProperties.getProperties()) {
+            String key = property.getKey();
+            if (values.containsKey(key)) {
+                continue;
+            }
+
+            values.put(key, property.getValue());
+            sources.put(key, folder.getFullName());
+            if (folderProperties.isExposeAtBuildStart()) {
+                buildStartValues.put(key, property.getValue());
+            }
+        }
+    }
+}

--- a/src/main/java/com/mig82/folders/properties/PropertiesLoader.java
+++ b/src/main/java/com/mig82/folders/properties/PropertiesLoader.java
@@ -1,13 +1,7 @@
 package com.mig82.folders.properties;
 
-import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.EnvVars;
-import hudson.model.Item;
-import hudson.model.ItemGroup;
 import hudson.model.Job;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import jenkins.model.Jenkins;
 
 /**
  * A PropertiesLoader which can be used in both Freestyle Job build wrapper and custom pipeline step.
@@ -16,55 +10,9 @@ import jenkins.model.Jenkins;
  * @author Miguelangel Fernandez Mendoza and Gong Yi
  */
 public class PropertiesLoader {
-    private static final Logger LOGGER = Logger.getLogger(PropertiesLoader.class.getName());
+    private static final FolderPropertyResolver RESOLVER = new FolderPropertyResolver();
 
     public static EnvVars loadFolderProperties(Job job) {
-        LOGGER.log(Level.FINER, "1. Searching for folder properties in ancestors of: {0}\n", job.getDisplayName());
-        ItemGroup parent = job.getParent();
-        EnvVars envVars = new EnvVars();
-        // Look in all the ancestors...
-        while (parent != null) {
-            if (parent instanceof AbstractFolder folder) {
-                LOGGER.log(Level.FINEST, "2. Searching for folder properties in: {0}\n", parent.getDisplayName());
-                FolderProperties folderProperties =
-                        (FolderProperties) folder.getProperties().get(FolderProperties.class);
-                if (folderProperties != null) {
-                    StringProperty[] newlyFoundProperties = folderProperties.getProperties();
-                    LOGGER.log(Level.FINER, "3. Found {0} folder properties in {1}\n", new Object[] {
-                        newlyFoundProperties.length, parent.getDisplayName()
-                    });
-                    // If we find folder project properties on this parent, we add all to the context.
-                    for (StringProperty property : newlyFoundProperties) {
-                        // Only add the property if it has not been already defined in a sub-folder.
-                        if (envVars.get(property.getKey()) == null) {
-                            LOGGER.log(Level.FINEST, "4. Adding ({0}, {1}) to the context env", new Object[] {
-                                property.getKey(), property.getValue()
-                            });
-                            envVars.put(property.getKey(), property.getValue());
-                        } else {
-                            LOGGER.log(
-                                    Level.FINEST,
-                                    "4. Will not add duplicate property {0} to the context env",
-                                    new Object[] {property.getKey()});
-                        }
-                    }
-                    LOGGER.log(Level.FINEST, "5. Context env: {0}", envVars.toString());
-                }
-            } else if (parent instanceof Jenkins) {
-                LOGGER.log(Level.FINEST, "2. Reached Jenkins root. Stopping search\n");
-            } else {
-                LOGGER.log(Level.WARNING, "2. Unknown parent type: {0} of class {1}\n", new Object[] {
-                    parent.getDisplayName(), parent.getClass().getName()
-                });
-            }
-            // In the next iteration we want to search for the parent of this parent.
-            if (parent instanceof Item item) {
-                parent = item.getParent();
-            } else {
-                parent = null;
-            }
-        }
-        LOGGER.log(Level.FINE, "6. Context env is: {0}", envVars.toString());
-        return envVars;
+        return new EnvVars(RESOLVER.resolve(job).getValues());
     }
 }

--- a/src/main/java/com/mig82/folders/properties/ResolvedFolderProperties.java
+++ b/src/main/java/com/mig82/folders/properties/ResolvedFolderProperties.java
@@ -1,8 +1,8 @@
 package com.mig82.folders.properties;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * An immutable snapshot of the folder properties resolved for a job.
@@ -42,6 +42,8 @@ public final class ResolvedFolderProperties {
     }
 
     private static Map<String, String> immutableCopy(Map<String, String> source) {
-        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+        Map<String, String> copy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        copy.putAll(source);
+        return Collections.unmodifiableMap(copy);
     }
 }

--- a/src/main/java/com/mig82/folders/properties/ResolvedFolderProperties.java
+++ b/src/main/java/com/mig82/folders/properties/ResolvedFolderProperties.java
@@ -1,0 +1,47 @@
+package com.mig82.folders.properties;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An immutable snapshot of the folder properties resolved for a job.
+ */
+public final class ResolvedFolderProperties {
+
+    private final Map<String, String> values;
+    private final Map<String, String> buildStartValues;
+    private final Map<String, String> sources;
+
+    ResolvedFolderProperties(
+            Map<String, String> values, Map<String, String> buildStartValues, Map<String, String> sources) {
+        this.values = immutableCopy(values);
+        this.buildStartValues = immutableCopy(buildStartValues);
+        this.sources = immutableCopy(sources);
+    }
+
+    /**
+     * Returns all resolved values, regardless of their exposure mode.
+     */
+    public Map<String, String> getValues() {
+        return values;
+    }
+
+    /**
+     * Returns the resolved values whose source folder opted into build-start exposure.
+     */
+    public Map<String, String> getBuildStartValues() {
+        return buildStartValues;
+    }
+
+    /**
+     * Returns the full name of the folder that supplied each resolved key.
+     */
+    public Map<String, String> getSources() {
+        return sources;
+    }
+
+    private static Map<String, String> immutableCopy(Map<String, String> source) {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+}

--- a/src/main/java/com/mig82/folders/step/FolderPropertiesStep.java
+++ b/src/main/java/com/mig82/folders/step/FolderPropertiesStep.java
@@ -38,8 +38,7 @@ public class FolderPropertiesStep extends Step implements Serializable {
         @Override
         public boolean start() throws Exception {
             Run<?, ?> run = getContext().get(Run.class);
-            EnvVars envVars =
-                    new EnvVars(FolderPropertiesSnapshotAction.getOrCreate(run).getValues());
+            EnvVars envVars = new EnvVars(FolderPropertiesSnapshotAction.resolveValues(run));
             BodyInvoker bodyInvoker = getContext().newBodyInvoker();
             if (!envVars.isEmpty()) {
                 bodyInvoker.withContext(EnvironmentExpander.merge(

--- a/src/main/java/com/mig82/folders/step/FolderPropertiesStep.java
+++ b/src/main/java/com/mig82/folders/step/FolderPropertiesStep.java
@@ -1,18 +1,14 @@
 package com.mig82.folders.step;
 
-import com.mig82.folders.properties.PropertiesLoader;
+import com.mig82.folders.environment.FolderPropertiesSnapshotAction;
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.steps.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -23,37 +19,34 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Miguelangel Fernandez Mendoza and Gong Yi
  */
 public class FolderPropertiesStep extends Step implements Serializable {
-    private static final Logger LOGGER = Logger.getLogger(FolderPropertiesStep.class.getName());
-
     @DataBoundConstructor
     public FolderPropertiesStep() {}
 
     @Override
     public StepExecution start(StepContext stepContext) throws Exception {
-        return new Execution(stepContext, this);
+        return new Execution(stepContext);
     }
 
-    private static class Execution extends SynchronousNonBlockingStepExecution<Void> {
-        private FolderPropertiesStep folderPropertiesStep;
+    private static class Execution extends StepExecution {
+        @Serial
+        private static final long serialVersionUID = 1;
 
-        public Execution(StepContext context, FolderPropertiesStep folderPropertiesStep) {
+        public Execution(StepContext context) {
             super(context);
-            this.folderPropertiesStep = folderPropertiesStep;
         }
 
         @Override
-        protected Void run() throws Exception {
-            LOGGER.log(Level.FINER, "Run in 'withFolderProperties' custom pipeline step");
-            Job job = getContext().get(Run.class).getParent();
-            EnvVars envVars = PropertiesLoader.loadFolderProperties(job);
+        public boolean start() throws Exception {
+            Run<?, ?> run = getContext().get(Run.class);
+            EnvVars envVars =
+                    new EnvVars(FolderPropertiesSnapshotAction.getOrCreate(run).getValues());
             BodyInvoker bodyInvoker = getContext().newBodyInvoker();
             if (!envVars.isEmpty()) {
-                LOGGER.log(Level.FINER, "Find the folder properties");
                 bodyInvoker.withContext(EnvironmentExpander.merge(
                         getContext().get(EnvironmentExpander.class), new ExpanderImpl(envVars)));
             }
-            bodyInvoker.start().get();
-            return null;
+            bodyInvoker.withCallback(BodyExecutionCallback.wrap(getContext())).start();
+            return false;
         }
     }
 
@@ -78,7 +71,7 @@ public class FolderPropertiesStep extends Step implements Serializable {
     public static class DescriptorImpl extends StepDescriptor {
         @Override
         public Set<Class<?>> getRequiredContext() {
-            return Collections.<Class<?>>singleton(TaskListener.class);
+            return Set.of(Run.class, TaskListener.class);
         }
 
         @Override

--- a/src/main/java/com/mig82/folders/wrappers/ParentFolderBuildWrapper.java
+++ b/src/main/java/com/mig82/folders/wrappers/ParentFolderBuildWrapper.java
@@ -48,7 +48,7 @@ public class ParentFolderBuildWrapper extends SimpleBuildWrapper {
 
         Map<String, String> env = context.getEnv();
         for (Map.Entry<String, String> entry :
-                FolderPropertiesSnapshotAction.getOrCreate(run).getValues().entrySet()) {
+                FolderPropertiesSnapshotAction.resolveValues(run).entrySet()) {
             String key = entry.getKey();
             if (!env.containsKey(key)) {
                 env.put(key, entry.getValue());

--- a/src/main/java/com/mig82/folders/wrappers/ParentFolderBuildWrapper.java
+++ b/src/main/java/com/mig82/folders/wrappers/ParentFolderBuildWrapper.java
@@ -1,7 +1,7 @@
 package com.mig82.folders.wrappers;
 
 import com.mig82.folders.Messages;
-import com.mig82.folders.properties.PropertiesLoader;
+import com.mig82.folders.environment.FolderPropertiesSnapshotAction;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -46,17 +46,15 @@ public class ParentFolderBuildWrapper extends SimpleBuildWrapper {
             EnvVars initialEnvironment)
             throws IOException, InterruptedException {
 
-        Job job = run.getParent(); // The parent of the run is the Job itself.
-        EnvVars envVars = PropertiesLoader.loadFolderProperties(job);
         Map<String, String> env = context.getEnv();
-        for (Map.Entry<String, String> entry : envVars.entrySet()) {
+        for (Map.Entry<String, String> entry :
+                FolderPropertiesSnapshotAction.getOrCreate(run).getValues().entrySet()) {
             String key = entry.getKey();
             if (!env.containsKey(key)) {
                 env.put(key, entry.getValue());
             }
         }
-
-        LOGGER.log(Level.FINE, "Context env is: {0}", context.getEnv().toString());
+        LOGGER.log(Level.FINER, "Added {0} folder property keys to the build wrapper", env.size());
     }
 
     @Symbol("withFolderProperties")

--- a/src/main/resources/com/mig82/folders/properties/FolderProperties/config.jelly
+++ b/src/main/resources/com/mig82/folders/properties/FolderProperties/config.jelly
@@ -1,8 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="${%properties.section}">
-	<f:entry title="${%properties.entry}" description="${%properties.desc}" field="properties">
-		<f:repeatableProperty field="properties"/>
-	</f:entry>
+    <f:entry title="${%properties.entry}" description="${%properties.desc}" field="properties">
+      <f:repeatableProperty field="properties"/>
+    </f:entry>
+    <f:entry title="${%exposeAtBuildStart.entry}" field="exposeAtBuildStart">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/com/mig82/folders/properties/FolderProperties/config.properties
+++ b/src/main/resources/com/mig82/folders/properties/FolderProperties/config.properties
@@ -1,3 +1,4 @@
 properties.section=Folder Properties
 properties.entry=Property List
 properties.desc=A list of simple String properties you can expose to the jobs contained in this folder.
+exposeAtBuildStart.entry=Expose these properties at build start

--- a/src/main/resources/com/mig82/folders/properties/FolderProperties/help-exposeAtBuildStart.html
+++ b/src/main/resources/com/mig82/folders/properties/FolderProperties/help-exposeAtBuildStart.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Help for build-start folder properties</title>
+</head>
+<body>
+    Exposes this folder's properties as defaults from the beginning of descendant builds. Enable this when a
+    Declarative <code>environment</code> block, Pipeline-from-SCM repository, branch, or Jenkinsfile path needs the
+    values before a build wrapper or <code>withFolderProperties</code> block can run.
+    <br>
+    A definition in a closer folder still wins. Build parameters and explicit Pipeline environment declarations may
+    override these defaults. The values are snapshotted when the build first requests its environment.
+    <br>
+    Git lightweight checkout does not expand variables in the remote URL; use a fixed URL or disable lightweight
+    checkout when the URL contains a folder property reference.
+</body>
+</html>

--- a/src/main/resources/com/mig82/folders/properties/FolderProperties/help-properties.html
+++ b/src/main/resources/com/mig82/folders/properties/FolderProperties/help-properties.html
@@ -10,6 +10,8 @@
     In structures where two or more folders are nested, any property defined for a folder will be overridden by any
     other property of the same name defined by one of its sub-folders.
     <br>
+    Property names are compared case-insensitively, matching Jenkins environment variable semantics.
+    <br>
     Freestyle jobs must opt into inheriting these properties by selecting the <em>Folder Properties</em> build wrapper
     from the <em>Build Environment</em> section of their configuration page.
     <br>
@@ -18,5 +20,7 @@
     Enable <em>Expose these properties at build start</em> only when Declarative environment evaluation or
     Pipeline-from-SCM configuration needs these values before a wrapper or Pipeline step can run. Build-start values
     act as defaults and are snapshotted for the duration of the build.
+    <br>
+    Without that setting, wrappers and Pipeline steps read the current folder configuration whenever they run.
 </body>
 </html>

--- a/src/main/resources/com/mig82/folders/properties/FolderProperties/help-properties.html
+++ b/src/main/resources/com/mig82/folders/properties/FolderProperties/help-properties.html
@@ -14,5 +14,9 @@
     from the <em>Build Environment</em> section of their configuration page.
     <br>
     Pipeline jobs can use step <em>withFolderProperties</em> to access them.
+    <br>
+    Enable <em>Expose these properties at build start</em> only when Declarative environment evaluation or
+    Pipeline-from-SCM configuration needs these values before a wrapper or Pipeline step can run. Build-start values
+    act as defaults and are snapshotted for the duration of the build.
 </body>
 </html>

--- a/src/test/java/com/mig82/folders/FolderPropertiesConfigurationTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesConfigurationTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.mig82.folders.properties.FolderProperties;
 import com.mig82.folders.properties.StringProperty;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.stapler.StaplerRequest2;
 
@@ -36,5 +37,20 @@ class FolderPropertiesConfigurationTest {
 
         assertEquals(FormValidation.Kind.ERROR, descriptor.doValidate("  ", "value").kind);
         assertEquals(FormValidation.Kind.OK, descriptor.doValidate("key", "value").kind);
+    }
+
+    @Test
+    void loadsLegacyConfigurationWithoutBuildStartField() {
+        FolderProperties<?> configured = new FolderProperties<>();
+        configured.setProperties(new StringProperty[] {new StringProperty("key", "value")});
+        String legacyXml =
+                Jenkins.XSTREAM2.toXML(configured).replaceAll("\\s*<exposeAtBuildStart>.*?</exposeAtBuildStart>", "");
+
+        FolderProperties<?> loaded = (FolderProperties<?>) Jenkins.XSTREAM2.fromXML(legacyXml);
+
+        assertFalse(legacyXml.contains("exposeAtBuildStart"));
+        assertFalse(loaded.isExposeAtBuildStart());
+        assertEquals(1, loaded.getProperties().length);
+        assertEquals("key", loaded.getProperties()[0].getKey());
     }
 }

--- a/src/test/java/com/mig82/folders/FolderPropertiesConfigurationTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesConfigurationTest.java
@@ -1,0 +1,40 @@
+package com.mig82.folders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.mig82.folders.properties.FolderProperties;
+import com.mig82.folders.properties.StringProperty;
+import hudson.util.FormValidation;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.StaplerRequest2;
+
+class FolderPropertiesConfigurationTest {
+
+    @Test
+    void preservesAppendSemanticsAndDefaultsToScopedExposure() {
+        FolderProperties<?> properties = new FolderProperties<>();
+
+        properties.setProperties(new StringProperty[] {new StringProperty("first", "one")});
+        properties.setProperties(new StringProperty[] {new StringProperty("second", "two")});
+
+        assertEquals(2, properties.getProperties().length);
+        assertEquals("first", properties.getProperties()[0].getKey());
+        assertEquals("second", properties.getProperties()[1].getKey());
+        assertFalse(properties.isExposeAtBuildStart());
+    }
+
+    @Test
+    void returnsNullWhenFolderPropertyIsRemovedFromConfiguration() throws Exception {
+        assertNull(new FolderProperties<>().reconfigure((StaplerRequest2) null, null));
+    }
+
+    @Test
+    void validatesPropertyKeys() {
+        StringProperty.DescriptorImpl descriptor = new StringProperty.DescriptorImpl();
+
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doValidate("  ", "value").kind);
+        assertEquals(FormValidation.Kind.OK, descriptor.doValidate("key", "value").kind);
+    }
+}

--- a/src/test/java/com/mig82/folders/FolderPropertiesPipelineRegressionTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesPipelineRegressionTest.java
@@ -1,0 +1,216 @@
+package com.mig82.folders;
+
+import static com.mig82.folders.FolderPropertyResolverTest.folder;
+import static com.mig82.folders.FolderPropertyResolverTest.property;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.mig82.folders.environment.FolderPropertiesSnapshotAction;
+import com.mig82.folders.properties.FolderProperties;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FolderPropertiesPipelineRegressionTest {
+
+    @Test
+    void propagatesBodyResultInDeclarativeWhen(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "issue-45", false, property("key", "value"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                pipeline {
+                  agent any
+                  stages {
+                    stage('conditional') {
+                      when {
+                        expression {
+                          withFolderProperties {
+                            return true
+                          }
+                        }
+                      }
+                      steps {
+                        echo 'ISSUE_45_STAGE_RAN'
+                      }
+                    }
+                  }
+                }
+                """);
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+        r.assertLogContains("ISSUE_45_STAGE_RAN", run);
+    }
+
+    @Test
+    void propagatesNonBooleanBodyResult(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "pipeline-body-result", false, property("key", "value"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                def result = withFolderProperties {
+                  return 'BODY_RESULT'
+                }
+                echo "result: ${result}"
+                """);
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+        r.assertLogContains("result: BODY_RESULT", run);
+    }
+
+    @Test
+    void exposesPropertiesBeforeRootDeclarativeEnvironment(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "issue-46", true, property("TEST_VAR", "TRUE"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                pipeline {
+                  agent none
+                  options {
+                    withFolderProperties()
+                  }
+                  environment {
+                    IS_SET = "${env.TEST_VAR}"
+                  }
+                  stages {
+                    stage('test') {
+                      agent any
+                      steps {
+                        echo "TEST_VAR: ${env.TEST_VAR}!!!"
+                        echo "IS_SET: ${env.IS_SET}!!!"
+                      }
+                    }
+                  }
+                }
+                """);
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+        r.assertLogContains("TEST_VAR: TRUE!!!", run);
+        r.assertLogContains("IS_SET: TRUE!!!", run);
+    }
+
+    @Test
+    void preservesScopedExpansionAndRemovesValuesAfterBody(JenkinsRule r) throws Exception {
+        Folder parent =
+                folder(r, "pipeline-scope", false, property("BASE", "value"), property("DERIVED", "${BASE}-derived"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                echo "before: ${env.BASE}"
+                withFolderProperties {
+                  echo "inside: ${env.DERIVED}"
+                }
+                echo "after: ${env.BASE}"
+                """);
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+        r.assertLogContains("before: null", run);
+        r.assertLogContains("inside: value-derived", run);
+        r.assertLogContains("after: null", run);
+    }
+
+    @Test
+    void propagatesBodyFailure(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "pipeline-failure", false, property("key", "value"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                withFolderProperties {
+                  error('EXPECTED_BODY_FAILURE')
+                }
+                """);
+
+        WorkflowRun run = r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+
+        r.assertLogContains("EXPECTED_BODY_FAILURE", run);
+    }
+
+    @Test
+    void snapshotsPropertiesOncePerRun(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "pipeline-snapshot", true, property("key", "initial"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", "echo \"key: ${env.key}\"");
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        FolderPropertiesSnapshotAction snapshot = run.getAction(FolderPropertiesSnapshotAction.class);
+
+        assertTrue(snapshot != null && snapshot.getValues().containsKey("key"));
+        assertFalse(snapshot.getSources().isEmpty());
+        assertTrue(snapshot.getValues().get("key").equals("initial"));
+    }
+
+    @Test
+    void persistsEarlyExposureConfiguration(JenkinsRule r) throws Exception {
+        Folder configured = folder(r, "pipeline-persistence", true, property("key", "value"));
+
+        Folder reloaded = r.configRoundtrip(configured);
+        FolderProperties<?> folderProperties = reloaded.getProperties().get(FolderProperties.class);
+
+        assertTrue(folderProperties.isExposeAtBuildStart());
+    }
+
+    @Test
+    void expandsEarlyValuesAndLetsParametersOverrideDefaults(JenkinsRule r) throws Exception {
+        Folder parent = folder(
+                r, "pipeline-early-defaults", true, property("BASE", "folder"), property("DERIVED", "${BASE}-derived"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                echo "base: ${env.BASE}"
+                echo "derived: ${env.DERIVED}"
+                """);
+        job.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("BASE", "default")));
+
+        WorkflowRun run = r.assertBuildStatusSuccess(
+                job.scheduleBuild2(0, new ParametersAction(new StringParameterValue("BASE", "parameter"))));
+
+        r.assertLogContains("base: parameter", run);
+        r.assertLogContains("derived: parameter-derived", run);
+    }
+
+    @Test
+    void letsDeclarativeEnvironmentOverrideEarlyDefaults(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "pipeline-early-declarative-override", true, property("KEY", "folder"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                pipeline {
+                  agent any
+                  environment {
+                    KEY = 'pipeline'
+                  }
+                  stages {
+                    stage('test') {
+                      steps {
+                        echo "key: ${env.KEY}"
+                      }
+                    }
+                  }
+                }
+                """);
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+        r.assertLogContains("key: pipeline", run);
+    }
+
+    @Test
+    void reusesSnapshotWhenFolderChangesDuringBuild(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "pipeline-snapshot-change", true, property("key", "initial"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                echo "first: ${env.key}"
+                sleep time: 2, unit: 'SECONDS'
+                withFolderProperties {
+                  echo "second: ${env.key}"
+                }
+                """);
+
+        WorkflowRun run = job.scheduleBuild2(0).waitForStart();
+        r.waitForMessage("Sleeping for 2 sec", run);
+        FolderProperties<?> properties = parent.getProperties().get(FolderProperties.class);
+        properties.getProperties()[0].setValue("changed");
+        parent.save();
+
+        r.assertBuildStatusSuccess(r.waitForCompletion(run));
+        r.assertLogContains("first: initial", run);
+        r.assertLogContains("second: initial", run);
+    }
+}

--- a/src/test/java/com/mig82/folders/FolderPropertiesPipelineRegressionTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesPipelineRegressionTest.java
@@ -3,6 +3,7 @@ package com.mig82.folders;
 import static com.mig82.folders.FolderPropertyResolverTest.folder;
 import static com.mig82.folders.FolderPropertyResolverTest.property;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
@@ -212,5 +213,48 @@ class FolderPropertiesPipelineRegressionTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(run));
         r.assertLogContains("first: initial", run);
         r.assertLogContains("second: initial", run);
+    }
+
+    @Test
+    void preservesDynamicResolutionWhenBuildStartExposureIsDisabled(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "pipeline-legacy-dynamic", false, property("key", "initial"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                withFolderProperties {
+                  echo "first: ${env.key}"
+                }
+                sleep time: 2, unit: 'SECONDS'
+                withFolderProperties {
+                  echo "second: ${env.key}"
+                }
+                """);
+
+        WorkflowRun run = job.scheduleBuild2(0).waitForStart();
+        r.waitForMessage("Sleeping for 2 sec", run);
+        FolderProperties<?> properties = parent.getProperties().get(FolderProperties.class);
+        properties.getProperties()[0].setValue("changed");
+        parent.save();
+
+        r.assertBuildStatusSuccess(r.waitForCompletion(run));
+        assertNull(run.getAction(FolderPropertiesSnapshotAction.class));
+        r.assertLogContains("first: initial", run);
+        r.assertLogContains("second: changed", run);
+    }
+
+    @Test
+    void caseVariantInCloserFolderSuppressesAncestorEarlyValue(JenkinsRule r) throws Exception {
+        Folder ancestor = folder(r, "pipeline-case-precedence", true, property("foo", "ancestor"));
+        Folder parent = folder(ancestor, "child", false, property("FOO", "child"));
+        WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                echo "before: ${env.FOO}"
+                withFolderProperties {
+                  echo "inside: ${env.foo}"
+                }
+                """);
+
+        WorkflowRun run = r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+        assertNull(run.getAction(FolderPropertiesSnapshotAction.class));
+        r.assertLogContains("before: null", run);
+        r.assertLogContains("inside: child", run);
     }
 }

--- a/src/test/java/com/mig82/folders/FolderPropertiesRestartTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesRestartTest.java
@@ -1,0 +1,54 @@
+package com.mig82.folders;
+
+import static com.mig82.folders.FolderPropertyResolverTest.folder;
+import static com.mig82.folders.FolderPropertyResolverTest.property;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.mig82.folders.environment.FolderPropertiesSnapshotAction;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
+
+class FolderPropertiesRestartTest {
+
+    @RegisterExtension
+    final JenkinsSessionExtension sessions = new JenkinsSessionExtension();
+
+    @Test
+    void resumesBodyAfterControllerRestart() throws Throwable {
+        AtomicInteger buildNumber = new AtomicInteger();
+
+        sessions.then(r -> {
+            Folder parent = folder(r, "issue-48", false, property("key", "restart-value"));
+            WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
+                    withFolderProperties {
+                      echo "before restart: ${env.key}"
+                      sleep time: 5, unit: 'SECONDS'
+                      echo "after restart: ${env.key}"
+                    }
+                    """);
+
+            WorkflowRun run = job.scheduleBuild2(0).waitForStart();
+            buildNumber.set(run.getNumber());
+            r.waitForMessage("Sleeping for 5 sec", run);
+        });
+
+        sessions.then(r -> {
+            WorkflowJob job = r.jenkins.getItemByFullName("issue-48/pipeline", WorkflowJob.class);
+            WorkflowRun run = job.getBuildByNumber(buildNumber.get());
+
+            r.assertBuildStatusSuccess(r.waitForCompletion(run));
+            FolderPropertiesSnapshotAction snapshot = run.getAction(FolderPropertiesSnapshotAction.class);
+            assertNotNull(snapshot);
+            assertEquals("restart-value", snapshot.getValues().get("key"));
+            r.assertLogContains("before restart: restart-value", run);
+            r.assertLogContains("after restart: restart-value", run);
+            r.assertLogNotContains("SynchronousResumeNotSupportedException", run);
+        });
+    }
+}

--- a/src/test/java/com/mig82/folders/FolderPropertiesRestartTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesRestartTest.java
@@ -24,7 +24,7 @@ class FolderPropertiesRestartTest {
         AtomicInteger buildNumber = new AtomicInteger();
 
         sessions.then(r -> {
-            Folder parent = folder(r, "issue-48", false, property("key", "restart-value"));
+            Folder parent = folder(r, "issue-48", true, property("key", "restart-value"));
             WorkflowJob job = PipelineTestHelper.createJob(parent, "pipeline", """
                     withFolderProperties {
                       echo "before restart: ${env.key}"

--- a/src/test/java/com/mig82/folders/FolderPropertiesScmTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertiesScmTest.java
@@ -1,0 +1,144 @@
+package com.mig82.folders;
+
+import static com.mig82.folders.FolderPropertyResolverTest.folder;
+import static com.mig82.folders.FolderPropertyResolverTest.property;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.git.BranchSpec;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FolderPropertiesScmTest {
+
+    @Test
+    void expandsRepositoryAndBranchBeforeFreestyleCheckout(JenkinsRule r) throws Exception {
+        Path repository = createRepository(r, "FREESTYLE_SCM_EXPANSION_WORKED");
+        Folder parent = folder(
+                r,
+                "freestyle-scm",
+                false,
+                property("SCM_URL", repository.toUri().toString()),
+                property("SCM_BRANCH", "*/main"));
+        FreeStyleProject project = FreestyleTestHelper.createJob(parent, "job");
+        project.setScm(scm("${SCM_URL}", "${SCM_BRANCH}"));
+
+        boolean previous = GitSCM.ALLOW_LOCAL_CHECKOUT;
+        GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+        try {
+            FreeStyleBuild build = r.assertBuildStatusSuccess(project.scheduleBuild2(0));
+            assertNotNull(build.getWorkspace());
+            assertTrue(build.getWorkspace().child("ci/Jenkinsfile").exists());
+        } finally {
+            GitSCM.ALLOW_LOCAL_CHECKOUT = previous;
+        }
+    }
+
+    @Test
+    void expandsRepositoryBranchAndScriptPathForFullCheckout(JenkinsRule r) throws Exception {
+        Path repository = createRepository(r, "FULL_SCM_EXPANSION_WORKED");
+        Folder parent = folder(
+                r,
+                "issue-47-full",
+                true,
+                property("SCM_URL", repository.toUri().toString()),
+                property("SCM_BRANCH", "*/main"),
+                property("SCRIPT_PATH", "ci/Jenkinsfile"));
+        GitSCM scm = scm("${SCM_URL}", "${SCM_BRANCH}");
+
+        WorkflowRun run = buildFromScm(r, parent, scm, "${SCRIPT_PATH}", false);
+
+        r.assertLogContains("FULL_SCM_EXPANSION_WORKED", run);
+    }
+
+    @Test
+    void expandsBranchAndScriptPathForLightweightCheckoutWithFixedUrl(JenkinsRule r) throws Exception {
+        Path repository = createRepository(r, "LIGHTWEIGHT_SCM_EXPANSION_WORKED");
+        Folder parent = folder(
+                r,
+                "issue-47-lightweight",
+                true,
+                property("SCM_BRANCH", "*/main"),
+                property("SCRIPT_PATH", "ci/Jenkinsfile"));
+        GitSCM scm = scm(repository.toUri().toString(), "${SCM_BRANCH}");
+
+        WorkflowRun run = buildFromScm(r, parent, scm, "${SCRIPT_PATH}", true);
+
+        r.assertLogContains("LIGHTWEIGHT_SCM_EXPANSION_WORKED", run);
+    }
+
+    private static WorkflowRun buildFromScm(
+            JenkinsRule r, Folder parent, GitSCM scm, String scriptPath, boolean lightweight) throws Exception {
+        boolean previous = GitSCM.ALLOW_LOCAL_CHECKOUT;
+        GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+        try {
+            WorkflowJob job = parent.createProject(WorkflowJob.class, "pipeline");
+            CpsScmFlowDefinition definition = new CpsScmFlowDefinition(scm, scriptPath);
+            definition.setLightweight(lightweight);
+            job.setDefinition(definition);
+            return r.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        } finally {
+            GitSCM.ALLOW_LOCAL_CHECKOUT = previous;
+        }
+    }
+
+    private static GitSCM scm(String url, String branch) {
+        return new GitSCM(
+                List.of(new UserRemoteConfig(url, null, null, null)),
+                List.of(new BranchSpec(branch)),
+                false,
+                Collections.emptyList(),
+                null,
+                null,
+                Collections.emptyList());
+    }
+
+    private static Path createRepository(JenkinsRule r, String message) throws Exception {
+        Path repository = Files.createTempDirectory(r.jenkins.getRootDir().toPath(), "folder-properties-git-");
+        runGit(repository, "init", "--initial-branch=main");
+        Path pipelineDirectory = Files.createDirectories(repository.resolve("ci"));
+        Files.writeString(
+                pipelineDirectory.resolve("Jenkinsfile"), "node { echo '" + message + "' }\n", StandardCharsets.UTF_8);
+        runGit(repository, "add", "ci/Jenkinsfile");
+        runGit(
+                repository,
+                "-c",
+                "user.name=Folder Properties Test",
+                "-c",
+                "user.email=folder-properties@example.invalid",
+                "commit",
+                "-m",
+                "Add Jenkinsfile");
+        return repository;
+    }
+
+    private static void runGit(Path directory, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 1];
+        command[0] = "git";
+        System.arraycopy(arguments, 0, command, 1, arguments.length);
+        Process process = new ProcessBuilder(command)
+                .directory(directory.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        if (process.waitFor() != 0) {
+            throw new IOException("git command failed: " + output);
+        }
+    }
+}

--- a/src/test/java/com/mig82/folders/FolderPropertyResolverTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertyResolverTest.java
@@ -1,0 +1,109 @@
+package com.mig82.folders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.mig82.folders.properties.FolderProperties;
+import com.mig82.folders.properties.FolderPropertyResolver;
+import com.mig82.folders.properties.PropertiesLoader;
+import com.mig82.folders.properties.ResolvedFolderProperties;
+import com.mig82.folders.properties.StringProperty;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FolderPropertyResolverTest {
+
+    @Test
+    void resolvesHierarchyAndTracksSources(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "resolver-parent", true, property("shared", "parent"), property("parent", "one"));
+        Folder child = folder(parent, "child", true, property("shared", "child"), property("child", "two"));
+        WorkflowJob job = child.createProject(WorkflowJob.class, "job");
+
+        ResolvedFolderProperties resolved = new FolderPropertyResolver().resolve(job);
+
+        assertEquals(Map.of("shared", "child", "child", "two", "parent", "one"), resolved.getValues());
+        assertEquals(resolved.getValues(), resolved.getBuildStartValues());
+        assertEquals(resolved.getValues(), PropertiesLoader.loadFolderProperties(job));
+        assertEquals("resolver-parent/child", resolved.getSources().get("shared"));
+        assertEquals("resolver-parent", resolved.getSources().get("parent"));
+    }
+
+    @Test
+    void closestDefinitionAlsoControlsEarlyExposure(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "resolver-exposure-parent", true, property("shared", "parent"));
+        Folder child = folder(parent, "child", false, property("shared", "child"), property("scoped", "only"));
+        WorkflowJob job = child.createProject(WorkflowJob.class, "job");
+
+        ResolvedFolderProperties resolved = new FolderPropertyResolver().resolve(job);
+
+        assertEquals("child", resolved.getValues().get("shared"));
+        assertTrue(resolved.getBuildStartValues().isEmpty());
+    }
+
+    @Test
+    void handlesMissingPropertiesAndDuplicateKeys(JenkinsRule r) throws Exception {
+        Folder empty = r.jenkins.createProject(Folder.class, "resolver-empty");
+        WorkflowJob emptyJob = empty.createProject(WorkflowJob.class, "empty-job");
+        assertTrue(new FolderPropertyResolver().resolve(emptyJob).getValues().isEmpty());
+
+        Folder duplicate = folder(
+                r,
+                "resolver-duplicate",
+                false,
+                property("duplicate", "first"),
+                property("duplicate", "second"),
+                property("empty", ""));
+        WorkflowJob duplicateJob = duplicate.createProject(WorkflowJob.class, "duplicate-job");
+        ResolvedFolderProperties resolved = new FolderPropertyResolver().resolve(duplicateJob);
+
+        assertEquals(Map.of("duplicate", "first", "empty", ""), resolved.getValues());
+        assertEquals(
+                List.of("duplicate", "empty"), List.copyOf(resolved.getValues().keySet()));
+        assertFalse(resolved.getSources().isEmpty());
+    }
+
+    @Test
+    void returnsImmutableMaps(JenkinsRule r) throws Exception {
+        Folder folder = folder(r, "resolver-immutable", true, property("key", "value"));
+        WorkflowJob job = folder.createProject(WorkflowJob.class, "job");
+        ResolvedFolderProperties resolved = new FolderPropertyResolver().resolve(job);
+
+        assertThrows(
+                UnsupportedOperationException.class, () -> resolved.getValues().put("other", "value"));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> resolved.getBuildStartValues().put("other", "value"));
+        assertThrows(
+                UnsupportedOperationException.class, () -> resolved.getSources().put("other", "folder"));
+    }
+
+    static Folder folder(JenkinsRule r, String name, boolean exposeAtBuildStart, StringProperty... properties)
+            throws Exception {
+        return configure(r.jenkins.createProject(Folder.class, name), exposeAtBuildStart, properties);
+    }
+
+    static Folder folder(Folder parent, String name, boolean exposeAtBuildStart, StringProperty... properties)
+            throws Exception {
+        return configure(parent.createProject(Folder.class, name), exposeAtBuildStart, properties);
+    }
+
+    static Folder configure(Folder folder, boolean exposeAtBuildStart, StringProperty... properties) throws Exception {
+        FolderProperties<?> folderProperties = new FolderProperties<>();
+        folderProperties.setExposeAtBuildStart(exposeAtBuildStart);
+        folderProperties.setProperties(properties);
+        folder.addProperty(folderProperties);
+        return folder;
+    }
+
+    static StringProperty property(String key, String value) {
+        return new StringProperty(key, value);
+    }
+}

--- a/src/test/java/com/mig82/folders/FolderPropertyResolverTest.java
+++ b/src/test/java/com/mig82/folders/FolderPropertyResolverTest.java
@@ -49,6 +49,21 @@ class FolderPropertyResolverTest {
     }
 
     @Test
+    void treatsEnvironmentVariableNamesAsCaseInsensitive(JenkinsRule r) throws Exception {
+        Folder parent = folder(r, "resolver-case-parent", true, property("foo", "parent"));
+        Folder child = folder(parent, "child", false, property("FOO", "child"));
+        WorkflowJob job = child.createProject(WorkflowJob.class, "job");
+
+        ResolvedFolderProperties resolved = new FolderPropertyResolver().resolve(job);
+
+        assertEquals(Map.of("FOO", "child"), resolved.getValues());
+        assertEquals("child", resolved.getValues().get("foo"));
+        assertTrue(resolved.getBuildStartValues().isEmpty());
+        assertEquals("resolver-case-parent/child", resolved.getSources().get("FOO"));
+        assertEquals("child", PropertiesLoader.loadFolderProperties(job).get("foo"));
+    }
+
+    @Test
     void handlesMissingPropertiesAndDuplicateKeys(JenkinsRule r) throws Exception {
         Folder empty = r.jenkins.createProject(Folder.class, "resolver-empty");
         WorkflowJob emptyJob = empty.createProject(WorkflowJob.class, "empty-job");


### PR DESCRIPTION
This pull request fixes folder property resolution across the Jenkins build and Pipeline lifecycle.

It introduces a shared resolver and an opt-in **Expose these properties at build start** setting. When enabled, folder properties are resolved and snapshotted early enough for Declarative
`environment` expressions and Pipeline-from-SCM configuration.

The closest folder definition wins case-insensitively and also controls whether a value is exposed at build start. Parameters and explicit Pipeline environment declarations can still
override these early defaults.

The `withFolderProperties` step is now an asynchronous, resumable block step. It:

- propagates its body result and failures;
- works inside and outside `node`;
- preserves block-scoped environment semantics;
- merges with existing environment expanders;
- resumes correctly after a Jenkins controller restart.

SCM support now covers:

- Freestyle repository and branch expansion before checkout;
- Pipeline-from-SCM repository URL, branch, and script path during full checkout;
- branch and script path during lightweight checkout.

The Git plugin does not expand a variable repository URL during lightweight checkout, so that limitation is documented.

Existing installations retain their previous behavior because build-start exposure defaults to `false`. Without early exposure, wrappers and scoped steps continue resolving the current
folder configuration dynamically.

This also simplifies the supported platform:

- minimum Jenkins version: 2.555.3 LTS;
- minimum Java version: 21;
- Jenkins plugin parent and BOM updated to the current LTS line;
- Linux and Windows CI standardized on JDK 21.

Fixes #45
Fixes #46
Fixes #47
Fixes #48

No upstream or downstream pull requests are required.

### Testing done

Automated validation was run with OpenJDK 21.0.11 and Maven 3.9.16:

```shell
mvn -ntp spotless:apply
mvn -ntp -Penable-jacoco clean verify
```

Results:

- 41 tests executed;
- 0 failures, 0 errors, and 0 skipped tests;
- SpotBugs completed with no findings;
- Spotless checks passed;
- JaCoCo coverage: 95.3% lines and 87.5% branches;
- HPI packaging completed successfully;
- the generated manifest requires Java 21 and Jenkins 2.555.3.

Regression coverage includes:

- propagation of boolean and non-boolean `withFolderProperties` body results;
- propagation of body failures;
- use inside a Declarative `when` expression;
- availability before root-level Declarative `environment` evaluation;
- parameter and Declarative environment precedence;
- nested-folder and case-insensitive precedence;
- scoped values being removed after the block;
- legacy dynamic resolution when build-start exposure is disabled;
- snapshot reuse when folder configuration changes during a build;
- persisted configuration and legacy XML without the new field;
- Freestyle pre-checkout SCM expansion;
- full and lightweight Pipeline-from-SCM expansion;
- Pipeline continuation after a Jenkins controller restart.

The new checkbox uses the standard Jenkins configuration control and its data binding is exercised through a Jenkins configuration round-trip test.

<!-- Attach a screenshot of the new "Expose these properties at build start"
      checkbox here before submitting, if required by the reviewers. -->

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<img width="1284" height="429" alt="image" src="https://github.com/user-attachments/assets/2b6b603a-dd77-4eb3-806a-3d0dc9d0f175" />
